### PR TITLE
Update RollupFunctions to allow int and float

### DIFF
--- a/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Class/RollupFunctions.cs
+++ b/msdyncrmWorkflowTools/msdyncrmWorkflowTools/Class/RollupFunctions.cs
@@ -206,7 +206,7 @@ namespace msdyncrmWorkflowTools
             {
                 return ((Money)obj).Value;
             }
-            else if (obj is decimal)
+            else if (obj is decimal || obj is int || obj is long || obj is short || obj is float || obj is double)
             { 
                 return Convert.ToDecimal(obj);
             }


### PR DESCRIPTION
The rollup was not using Whole Number or any non Decimal or Money field.  This will fix it for that use case.